### PR TITLE
Support for authority records ( /auth ) endpoint

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,5 @@
+const FETCH_API_PATH_GET_RECORD = '/cgi-bin/getSingleRecord.cgi';
+
+module.exports = {
+  FETCH_API_PATH_GET_RECORD
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,8 @@
         body_parser = require('body-parser'),
         utils = require('./utils'),
         createBibRouter = require('./resources/bib'),
+        createAuthorityRouter = require('./resources/auth'),
+        createAuthorityService = require('./services/authority-service'),
         app = express();
 
     function initializeOptions(options) {
@@ -94,7 +96,26 @@
       fetchApi: options.fetchApi,
       externalURL: options.externalURL
     }, createVoyagerBatchcat), handleUnroutedMiddleware, logRequestMiddleware);
-    
+
+
+    const createVoyagerBatchcatDef = require('voyager-batchcat-js');
+  
+    const voagerBatchcat = createVoyagerBatchcatDef({
+      iniDir: options.iniFile
+    });
+
+    const authorityService = createAuthorityService({
+      fetchApi: options.fetchApi,
+      externalURL: options.externalURL
+    }, voagerBatchcat);
+
+    const logger = {
+      log: console.log.bind(console),
+      error: console.error.bind(console)
+    };
+
+    app.use('/auth', createAuthorityRouter(authorityService, logger));
+
     app.use(function(request, response, next) {
       response.status(404);
       next();
@@ -112,5 +133,3 @@
   };
 
 }());
-
-

--- a/lib/main.js
+++ b/lib/main.js
@@ -114,7 +114,11 @@
       error: console.error.bind(console)
     };
 
-    app.use('/auth', createAuthorityRouter(authorityService, logger));
+    const authorityRouterOptions = {
+      externalURL: options.externalURL
+    };
+
+    app.use('/auth', createAuthorityRouter(authorityService, logger, authorityRouterOptions));
 
     app.use(function(request, response, next) {
       response.status(404);

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,5 +1,6 @@
 const HttpStatus = require('http-status-codes');
 const utils = require('./utils');
+const difference = require('lodash.difference');
 
 function checkCredentials(creds) {
   if (!(typeof creds === 'object' && typeof creds.username === 'string' && typeof creds.password === 'string')) {
@@ -45,6 +46,22 @@ function parseRecord(request, response, next) {
   }    
 }
 
+function requireQueryParams(requiredQueryParams) {
+  return function(request, response, next) {
+    
+    const missingQueryParams = difference(requiredQueryParams, Object.keys(request.query));
+    if (missingQueryParams.length === 0) {
+      next();
+    } else {
+      response.status(HttpStatus.BAD_REQUEST).type('application/json').send({
+        error: {
+          message: 'The following parameters are required: ' + missingQueryParams.join(', ')
+        }
+      });
+    }
+  };
+}
+
 module.exports = {
-  requireCredentials, requireBody, parseRecord
+  requireCredentials, requireBody, parseRecord, requireQueryParams
 };

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,0 +1,50 @@
+const HttpStatus = require('http-status-codes');
+const utils = require('./utils');
+
+function checkCredentials(creds) {
+  if (!(typeof creds === 'object' && typeof creds.username === 'string' && typeof creds.password === 'string')) {
+    throw new Error('Credentials not provided');
+  }
+}
+
+function requireCredentials(request, response, next) {
+
+  const creds = utils.getCredentials(request);
+
+  try {
+    checkCredentials(creds);
+    request.userCredentials = creds;
+    next();
+  } catch (e) {
+    response.status(HttpStatus.UNAUTHORIZED).end();
+    return;
+  }
+}
+
+function requireBody(request, response, next) {
+
+  if (typeof request.body !== 'string') {
+    response.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).end();
+  } else {
+    next();
+  }
+}
+
+function parseRecord(request, response, next) {
+
+  try {
+    const record = utils.parseRecord(request.body);
+    request.record = record;
+    next();
+  } catch (e) {
+    response.status(HttpStatus.BAD_REQUEST).type('application/json').send({
+      error: {
+        message: 'Invalid record data'
+      }
+    });
+  }    
+}
+
+module.exports = {
+  requireCredentials, requireBody, parseRecord
+};

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const HttpStatus = require('http-status-codes');
 const Middlewares = require('../middlewares');
+const utils = require('../utils');
 
 module.exports = (authorityService, logger) => {
 
@@ -14,7 +15,7 @@ module.exports = (authorityService, logger) => {
 
     authorityService.get(recordId)
       .then((record) => {
-        response.type('application/xml').send(record);
+        response.type('application/xml').send(utils.serializeRecord(record));
       })
       .catch(error => {
         logger.error(`Error reading authority ${recordId}`, error);

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const express = require('express');
+const HttpStatus = require('http-status-codes');
+
+const utils = require('../utils');
+
+function checkCredentials(creds) {
+  if (!(typeof creds === 'object' && typeof creds.username === 'string' && typeof creds.password === 'string')) {
+    throw new Error('Credentials not provided');
+  }
+}
+
+function requireCredentialsMiddleware(request, response, next) {
+
+  const creds = utils.getCredentials(request);
+
+  try {
+    checkCredentials(creds);
+    request.userCredentials = creds;
+    next();
+  } catch (e) {
+    response.status(HttpStatus.UNAUTHORIZED).end();
+    return;
+  }
+}
+
+function requireBodyMiddleware(request, response, next) {
+
+  if (typeof request.body !== 'string') {
+    response.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).end();
+  } else {
+    next();
+  }
+}
+
+function parseRecordMiddleware(request, response, next) {
+
+  try {
+    const record = utils.parseRecord(request.body);
+    request.record = record;
+    next();
+  } catch (e) {
+    response.status(HttpStatus.BAD_REQUEST).type('application/json').send({
+      error: {
+        message: 'Invalid record data'
+      }
+    });
+  }    
+}
+
+module.exports = (authorityService, logger) => {
+
+  const router = new express.Router();
+
+  router.get('/:id', (request, response) => {
+
+    const recordId = request.params.id;
+
+    authorityService.get(recordId)
+      .then((record) => {
+        response.type('application/xml').send(record);
+      })
+      .catch(error => {
+        logger.error(`Error reading authority ${recordId}`, error);
+        response.status(HttpStatus.INTERNAL_SERVER_ERROR).end();
+      });
+  });
+
+  router.put('/:id', requireCredentialsMiddleware, requireBodyMiddleware, parseRecordMiddleware, (request, response) => {
+    const recordId = request.params.id;
+    const creds = request.userCredentials;
+    const record = request.record;
+
+    authorityService.update(creds, recordId, record)
+    .then(record => {
+      response.type('application/xml').send(record);
+    })
+    .catch(error => {
+      logger.error(`Error updating authority ${recordId}`, error);
+      response.status(HttpStatus.INTERNAL_SERVER_ERROR);
+    });  
+  });
+
+  router.post('/', requireCredentialsMiddleware, requireBodyMiddleware, parseRecordMiddleware, (request, response) => {
+    const recordId = request.params.id;
+    const creds = request.userCredentials;
+    const record = request.record;
+
+    authorityService.create(creds, recordId, record)
+    .then(record => {
+      response.type('application/xml').send(record);
+    })
+    .catch(error => {
+      logger.error('`Error creating authority', error);
+      response.status(HttpStatus.INTERNAL_SERVER_ERROR);
+    });  
+  });
+
+
+
+  return router;
+};

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -27,8 +27,9 @@ module.exports = (authorityService, logger) => {
     const recordId = request.params.id;
     const creds = request.userCredentials;
     const record = request.record;
+    const catLocation = request.query.catLocation;
 
-    authorityService.update(creds, recordId, record)
+    authorityService.update(creds, catLocation, recordId, record)
     .then(record => {
       response.type('application/xml').send(record);
     })
@@ -39,11 +40,11 @@ module.exports = (authorityService, logger) => {
   });
 
   router.post('/', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, (request, response) => {
-    const recordId = request.params.id;
     const creds = request.userCredentials;
     const record = request.record;
+    const catLocation = request.query.catLocation;
 
-    authorityService.create(creds, recordId, record)
+    authorityService.create(creds, catLocation, record)
     .then(record => {
       response.type('application/xml').send(record);
     })
@@ -52,7 +53,6 @@ module.exports = (authorityService, logger) => {
       response.status(HttpStatus.INTERNAL_SERVER_ERROR);
     });  
   });
-
 
 
   return router;

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -2,52 +2,7 @@
 
 const express = require('express');
 const HttpStatus = require('http-status-codes');
-
-const utils = require('../utils');
-
-function checkCredentials(creds) {
-  if (!(typeof creds === 'object' && typeof creds.username === 'string' && typeof creds.password === 'string')) {
-    throw new Error('Credentials not provided');
-  }
-}
-
-function requireCredentialsMiddleware(request, response, next) {
-
-  const creds = utils.getCredentials(request);
-
-  try {
-    checkCredentials(creds);
-    request.userCredentials = creds;
-    next();
-  } catch (e) {
-    response.status(HttpStatus.UNAUTHORIZED).end();
-    return;
-  }
-}
-
-function requireBodyMiddleware(request, response, next) {
-
-  if (typeof request.body !== 'string') {
-    response.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).end();
-  } else {
-    next();
-  }
-}
-
-function parseRecordMiddleware(request, response, next) {
-
-  try {
-    const record = utils.parseRecord(request.body);
-    request.record = record;
-    next();
-  } catch (e) {
-    response.status(HttpStatus.BAD_REQUEST).type('application/json').send({
-      error: {
-        message: 'Invalid record data'
-      }
-    });
-  }    
-}
+const Middlewares = require('../middlewares');
 
 module.exports = (authorityService, logger) => {
 
@@ -67,7 +22,7 @@ module.exports = (authorityService, logger) => {
       });
   });
 
-  router.put('/:id', requireCredentialsMiddleware, requireBodyMiddleware, parseRecordMiddleware, (request, response) => {
+  router.put('/:id', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, (request, response) => {
     const recordId = request.params.id;
     const creds = request.userCredentials;
     const record = request.record;
@@ -82,7 +37,7 @@ module.exports = (authorityService, logger) => {
     });  
   });
 
-  router.post('/', requireCredentialsMiddleware, requireBodyMiddleware, parseRecordMiddleware, (request, response) => {
+  router.post('/', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, (request, response) => {
     const recordId = request.params.id;
     const creds = request.userCredentials;
     const record = request.record;

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -5,7 +5,7 @@ const HttpStatus = require('http-status-codes');
 const Middlewares = require('../middlewares');
 const utils = require('../utils');
 
-module.exports = (authorityService, logger) => {
+module.exports = (authorityService, logger, options) => {
 
   const router = new express.Router();
 
@@ -30,12 +30,12 @@ module.exports = (authorityService, logger) => {
     const catLocation = request.query.catLocation;
 
     authorityService.update(creds, catLocation, recordId, record)
-    .then(record => {
-      response.type('application/xml').send(record);
+    .then(() => {
+      response.type('application/xml').status(HttpStatus.NO_CONTENT).end();
     })
     .catch(error => {
       logger.error(`Error updating authority ${recordId}`, error);
-      response.status(HttpStatus.INTERNAL_SERVER_ERROR);
+      response.status(HttpStatus.INTERNAL_SERVER_ERROR).end();
     });  
   });
 
@@ -45,12 +45,21 @@ module.exports = (authorityService, logger) => {
     const catLocation = request.query.catLocation;
 
     authorityService.create(creds, catLocation, record)
-    .then(record => {
-      response.type('application/xml').send(record);
+    .then(recordId => {
+
+      const externalUrl = options && options.externalURL || '';
+      const resourceLocation = `${externalUrl}/auth/${recordId}`;
+      
+      response
+        .type('application/xml')
+        .location(resourceLocation)
+        .set({ 'Resource-Id': recordId })
+        .status(HttpStatus.CREATED)
+        .end();
     })
     .catch(error => {
       logger.error('Error creating authority', error);
-      response.status(HttpStatus.INTERNAL_SERVER_ERROR);
+      response.status(HttpStatus.INTERNAL_SERVER_ERROR).end();
     });  
   });
 

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -63,5 +63,20 @@ module.exports = (authorityService, logger, options) => {
     });  
   });
 
+
+  router.delete('/:id', Middlewares.requireCredentials, (request, response) => {
+    const recordId = request.params.id;
+    const creds = request.userCredentials;
+
+    authorityService.delete(creds, recordId)
+    .then(() => {
+      response.type('application/xml').status(HttpStatus.NO_CONTENT).end();
+    })
+    .catch(error => {
+      logger.error(`Error updating authority ${recordId}`, error);
+      response.status(HttpStatus.INTERNAL_SERVER_ERROR).end();
+    });
+  });
+
   return router;
 };

--- a/lib/resources/auth.js
+++ b/lib/resources/auth.js
@@ -23,7 +23,7 @@ module.exports = (authorityService, logger) => {
       });
   });
 
-  router.put('/:id', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, (request, response) => {
+  router.put('/:id', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, Middlewares.requireQueryParams(['catLocation']), (request, response) => {
     const recordId = request.params.id;
     const creds = request.userCredentials;
     const record = request.record;
@@ -39,7 +39,7 @@ module.exports = (authorityService, logger) => {
     });  
   });
 
-  router.post('/', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, (request, response) => {
+  router.post('/', Middlewares.requireCredentials, Middlewares.requireBody, Middlewares.parseRecord, Middlewares.requireQueryParams(['catLocation']), (request, response) => {
     const creds = request.userCredentials;
     const record = request.record;
     const catLocation = request.query.catLocation;
@@ -49,11 +49,10 @@ module.exports = (authorityService, logger) => {
       response.type('application/xml').send(record);
     })
     .catch(error => {
-      logger.error('`Error creating authority', error);
+      logger.error('Error creating authority', error);
       response.status(HttpStatus.INTERNAL_SERVER_ERROR);
     });  
   });
-
 
   return router;
 };

--- a/lib/resources/auth.spec.js
+++ b/lib/resources/auth.spec.js
@@ -11,8 +11,10 @@ const express = require('express');
 const HttpStatus = require('http-status-codes');
 const createAuthorityRouter = require('./auth');
 const bodyParser = require('body-parser');
+const utils = require('../utils');
 
 const fakeRecordData = fs.readFileSync(path.resolve(__dirname, '../../test-utils/fake-data/record-xml-slim.xml'), 'utf8');
+const fakeRecord = utils.parseRecord(fakeRecordData);
 
 describe('Authority Routehandler', () => {
   let app;
@@ -55,18 +57,16 @@ describe('Authority Routehandler', () => {
 
   describe('get authority record', function() {
     
-    it('should respond with the requested record', () => {
+    it('should respond with the requested record in serialized format', () => {
 
-      const fakeRecordData = 'fake-record-data';
-      
-      authorityServiceMock.get.resolves(fakeRecordData);
+      authorityServiceMock.get.resolves(fakeRecord);
       
       return request(app)
         .get('/auth/123')
         .expect('Content-Type', /application\/xml/)
         .expect(HttpStatus.OK)
         .then(response => {
-          expect(response.text).to.eql(fakeRecordData);
+          expect(response.text).to.eql(utils.serializeRecord(fakeRecord));
         });
     });
 

--- a/lib/resources/auth.spec.js
+++ b/lib/resources/auth.spec.js
@@ -26,6 +26,10 @@ describe('Authority Routehandler', () => {
     password: 'pass'
   };
 
+  const fakeAuthorityRouterOptions = {
+    externalURL: 'http://fake-server-external-hostname:3333'
+  };
+
   beforeEach(() => {
 
     loggerSpy = {
@@ -46,7 +50,7 @@ describe('Authority Routehandler', () => {
     }));
 
 
-    const authorityRouteHandler = createAuthorityRouter(authorityServiceMock, loggerSpy);
+    const authorityRouteHandler = createAuthorityRouter(authorityServiceMock, loggerSpy, fakeAuthorityRouterOptions);
     app.use('/auth', authorityRouteHandler);
 
   });
@@ -110,11 +114,9 @@ describe('Authority Routehandler', () => {
         .expect(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     });
 
-    it('should respond with the updated record', () => {
+    it('should respond with 204 NO_CONTENT when update is successful', () => {
       const fakeCatLocationId = '95';
-      const updatedRecordData = 'fake-updated-record-data';
-
-      authorityServiceMock.update.resolves(updatedRecordData);
+      authorityServiceMock.update.resolves();
       
       return request(app)
         .put('/auth/123')
@@ -122,10 +124,9 @@ describe('Authority Routehandler', () => {
         .auth(fakeCreds.username, fakeCreds.password)
         .send(fakeRecordData)
         .type('application/xml')
-        .expect(HttpStatus.OK)
+        .expect(HttpStatus.NO_CONTENT)
         .expect('Content-Type', /application\/xml/)
-        .then(response => {
-          expect(response.text).to.eql(updatedRecordData);
+        .then(() => {
           expect(authorityServiceMock.update).to.have.been.calledWith(
             {username: fakeCreds.username, password: fakeCreds.password}, fakeCatLocationId, '123', sinon.match.any
           );
@@ -134,9 +135,7 @@ describe('Authority Routehandler', () => {
 
     it('should respond with BAD_REQUEST if there are missing query parameters', () => {
 
-      const updatedRecordData = 'fake-updated-record-data';
-
-      authorityServiceMock.update.resolves(updatedRecordData);
+      authorityServiceMock.update.resolves();
       
       return request(app)
         .put('/auth/123')
@@ -148,7 +147,6 @@ describe('Authority Routehandler', () => {
           expect(response.body.error.message).to.contain('The following parameters are required');
           expect(response.body.error.message).to.contain('catLocation');
         });
-       
     });
 
     it('should respond with BAD_REQUEST if record is in invalid format', () => {
@@ -179,11 +177,11 @@ describe('Authority Routehandler', () => {
         .expect(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     });
 
-    it('should respond with the updated record', () => {
+    it('should respond with 201 CREATED with headers indicating newly created record location', () => {
       const fakeCatLocationId = '95';
-      const updatedRecordData = 'fake-updated-record-data';
+      const createdRecordId = '1238123';
 
-      authorityServiceMock.create.resolves(updatedRecordData);
+      authorityServiceMock.create.resolves(createdRecordId);
       
       return request(app)
         .post('/auth/')
@@ -191,10 +189,11 @@ describe('Authority Routehandler', () => {
         .auth(fakeCreds.username, fakeCreds.password)
         .send(fakeRecordData)
         .type('application/xml')
-        .expect(HttpStatus.OK)
+        .expect(HttpStatus.CREATED)
         .expect('Content-Type', /application\/xml/)
-        .then(response => {
-          expect(response.text).to.eql(updatedRecordData);
+        .expect('Location', 'http://fake-server-external-hostname:3333/auth/1238123')
+        .expect('Resource-Id', createdRecordId)
+        .then(() => {
           expect(authorityServiceMock.create).to.have.been.calledWith(
             {username: fakeCreds.username, password: fakeCreds.password}, sinon.match.any
           );
@@ -203,7 +202,7 @@ describe('Authority Routehandler', () => {
 
     it('should respond with BAD_REQUEST if record is in invalid format', () => {
 
-      const invalidXMLRecordData = 'fake-updated-record-data';
+      const invalidXMLRecordData = 'fake-created-record-data';
 
       return request(app)
         .post('/auth/')

--- a/lib/resources/auth.spec.js
+++ b/lib/resources/auth.spec.js
@@ -40,7 +40,8 @@ describe('Authority Routehandler', () => {
     authorityServiceMock = {
       get: sinon.stub(),
       update: sinon.stub(),
-      create: sinon.stub()
+      create: sinon.stub(),
+      delete: sinon.stub()
     };
 
     app = express();
@@ -212,4 +213,31 @@ describe('Authority Routehandler', () => {
         .expect(HttpStatus.BAD_REQUEST);
     });
   });
+
+
+  describe('delete authority record', function() {
+    
+    it('should respond with 401 UNAUTHORIZED if credentials are missing', () => {
+      return request(app)
+        .delete('/auth/123')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should respond with 204 NO_CONTENT when delete is successful', () => {
+      authorityServiceMock.delete.resolves();
+      
+      return request(app)
+        .delete('/auth/123')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .type('application/xml')
+        .expect(HttpStatus.NO_CONTENT)
+        .expect('Content-Type', /application\/xml/)
+        .then(() => {
+          expect(authorityServiceMock.delete).to.have.been.calledWith(
+            {username: fakeCreds.username, password: fakeCreds.password}, '123'
+          );
+        });
+    });
+  });
+
 });

--- a/lib/resources/auth.spec.js
+++ b/lib/resources/auth.spec.js
@@ -1,0 +1,198 @@
+const sinon = require('sinon');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const request = require('supertest');
+chai.use(sinonChai);
+const expect = chai.expect;
+
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+const HttpStatus = require('http-status-codes');
+const createAuthorityRouter = require('./auth');
+const bodyParser = require('body-parser');
+
+const fakeRecordData = fs.readFileSync(path.resolve(__dirname, '../../test-utils/fake-data/record-xml-slim.xml'), 'utf8');
+
+describe('Authority Routehandler', () => {
+  let app;
+  let authorityServiceMock;
+  let loggerSpy;
+
+  const fakeCreds = {
+    username: 'user',
+    password: 'pass'
+  };
+
+  beforeEach(() => {
+
+    loggerSpy = {
+      log: sinon.spy(),
+      error: sinon.spy()
+    };
+
+    authorityServiceMock = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+      create: sinon.stub()
+    };
+
+    app = express();
+
+    app.use(bodyParser.text({
+      type: 'application/xml'
+    }));
+
+
+    const authorityRouteHandler = createAuthorityRouter(authorityServiceMock, loggerSpy);
+    app.use('/auth', authorityRouteHandler);
+
+  });
+
+  it('should be a factory function', () => {
+    expect(createAuthorityRouter).to.be.a('function');
+  });
+
+  describe('get authority record', function() {
+    
+    it('should respond with the requested record', () => {
+
+      const fakeRecordData = 'fake-record-data';
+      
+      authorityServiceMock.get.resolves(fakeRecordData);
+      
+      return request(app)
+        .get('/auth/123')
+        .expect('Content-Type', /application\/xml/)
+        .expect(HttpStatus.OK)
+        .then(response => {
+          expect(response.text).to.eql(fakeRecordData);
+        });
+    });
+
+
+    it('should respond with an error if request fails', () => {
+
+      const authorityReadError = new Error('fake-error-data');
+      authorityServiceMock.get.rejects(authorityReadError);
+      
+      return request(app)
+        .get('/auth/123')
+        .expect(HttpStatus.INTERNAL_SERVER_ERROR);
+    });
+
+    it('should log the error if request fails', () => {
+
+      const authorityReadError = new Error('fake-error-data');
+      authorityServiceMock.get.rejects(authorityReadError);
+      
+      return request(app)
+        .get('/auth/123')
+        .then(() => {
+          expect(loggerSpy.error).to.have.been.calledWith('Error reading authority 123', authorityReadError);
+        });
+    });
+
+  });
+
+  describe('put authority record', function() {
+    
+    it('should respond with 401 UNAUTHORIZED if credentials are missing', () => {
+      return request(app)
+        .put('/auth/123')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should respond with 415 UNSUPPORTED_MEDIA_TYPE if body is missing', () => {
+      return request(app)
+        .put('/auth/123')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .expect(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    });
+
+    it('should respond with the updated record', () => {
+
+      const updatedRecordData = 'fake-updated-record-data';
+
+      authorityServiceMock.update.resolves(updatedRecordData);
+      
+      return request(app)
+        .put('/auth/123')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .send(fakeRecordData)
+        .type('application/xml')
+        .expect(HttpStatus.OK)
+        .expect('Content-Type', /application\/xml/)
+        .then(response => {
+          expect(response.text).to.eql(updatedRecordData);
+          expect(authorityServiceMock.update).to.have.been.calledWith(
+            {username: fakeCreds.username, password: fakeCreds.password}, '123', sinon.match.any
+          );
+        });
+    });
+
+    it('should respond with BAD_REQUEST if record is in invalid format', () => {
+
+      const invalidXMLRecordData = 'fake-updated-record-data';
+
+      return request(app)
+        .put('/auth/123')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .send(invalidXMLRecordData)
+        .type('application/xml')
+        .expect(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe('post authority record', function() {
+    
+    it('should respond with 401 UNAUTHORIZED if credentials are missing', () => {
+      return request(app)
+        .post('/auth/')
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should respond with 415 UNSUPPORTED_MEDIA_TYPE if body is missing', () => {
+      return request(app)
+        .post('/auth/')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .expect(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    });
+
+    it('should respond with the updated record', () => {
+
+      const updatedRecordData = 'fake-updated-record-data';
+
+      authorityServiceMock.create.resolves(updatedRecordData);
+      
+      return request(app)
+        .post('/auth/')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .send(fakeRecordData)
+        .type('application/xml')
+        .expect(HttpStatus.OK)
+        .expect('Content-Type', /application\/xml/)
+        .then(response => {
+          expect(response.text).to.eql(updatedRecordData);
+          expect(authorityServiceMock.create).to.have.been.calledWith(
+            {username: fakeCreds.username, password: fakeCreds.password}, sinon.match.any
+          );
+        });
+    });
+
+    it('should respond with BAD_REQUEST if record is in invalid format', () => {
+
+      const invalidXMLRecordData = 'fake-updated-record-data';
+
+      return request(app)
+        .post('/auth/')
+        .auth(fakeCreds.username, fakeCreds.password)
+        .send(invalidXMLRecordData)
+        .type('application/xml')
+        .expect(HttpStatus.BAD_REQUEST);
+    });
+
+  });
+
+
+});

--- a/lib/resources/auth.spec.js
+++ b/lib/resources/auth.spec.js
@@ -111,6 +111,28 @@ describe('Authority Routehandler', () => {
     });
 
     it('should respond with the updated record', () => {
+      const fakeCatLocationId = '95';
+      const updatedRecordData = 'fake-updated-record-data';
+
+      authorityServiceMock.update.resolves(updatedRecordData);
+      
+      return request(app)
+        .put('/auth/123')
+        .query({ catLocation: fakeCatLocationId })
+        .auth(fakeCreds.username, fakeCreds.password)
+        .send(fakeRecordData)
+        .type('application/xml')
+        .expect(HttpStatus.OK)
+        .expect('Content-Type', /application\/xml/)
+        .then(response => {
+          expect(response.text).to.eql(updatedRecordData);
+          expect(authorityServiceMock.update).to.have.been.calledWith(
+            {username: fakeCreds.username, password: fakeCreds.password}, fakeCatLocationId, '123', sinon.match.any
+          );
+        });
+    });
+
+    it('should respond with BAD_REQUEST if there are missing query parameters', () => {
 
       const updatedRecordData = 'fake-updated-record-data';
 
@@ -121,14 +143,12 @@ describe('Authority Routehandler', () => {
         .auth(fakeCreds.username, fakeCreds.password)
         .send(fakeRecordData)
         .type('application/xml')
-        .expect(HttpStatus.OK)
-        .expect('Content-Type', /application\/xml/)
+        .expect(HttpStatus.BAD_REQUEST)
         .then(response => {
-          expect(response.text).to.eql(updatedRecordData);
-          expect(authorityServiceMock.update).to.have.been.calledWith(
-            {username: fakeCreds.username, password: fakeCreds.password}, '123', sinon.match.any
-          );
+          expect(response.body.error.message).to.contain('The following parameters are required');
+          expect(response.body.error.message).to.contain('catLocation');
         });
+       
     });
 
     it('should respond with BAD_REQUEST if record is in invalid format', () => {
@@ -160,13 +180,14 @@ describe('Authority Routehandler', () => {
     });
 
     it('should respond with the updated record', () => {
-
+      const fakeCatLocationId = '95';
       const updatedRecordData = 'fake-updated-record-data';
 
       authorityServiceMock.create.resolves(updatedRecordData);
       
       return request(app)
         .post('/auth/')
+        .query({ catLocation: fakeCatLocationId })
         .auth(fakeCreds.username, fakeCreds.password)
         .send(fakeRecordData)
         .type('application/xml')
@@ -191,8 +212,5 @@ describe('Authority Routehandler', () => {
         .type('application/xml')
         .expect(HttpStatus.BAD_REQUEST);
     });
-
   });
-
-
 });

--- a/lib/services/authority-service.js
+++ b/lib/services/authority-service.js
@@ -13,28 +13,26 @@ function createAuthorityService(options, batchcatConnector) {
    
   }
 
-  function updateRecord(userCredentials, library, catLocation, opacSuppress, recordId, record) {
-    
-    batchcatConnector.auth.addRecord(record, library, catLocation, opacSuppress, {
+  function createRecord(userCredentials, catLocation, record) {
+   
+    return batchcatConnector.auth.addRecord(record, catLocation, {
       username: userCredentials.username,
       password: userCredentials.password
     });
 
-    return recordId;
   }
 
-  function createRecord(userCredentials, library, catLocation, opacSuppress, record) {
-   
-    const recordId = batchcatConnector.auth.updateRecord(record, library, catLocation, opacSuppress, {
+  function updateRecord(userCredentials, catLocation, recordId, record) {
+    
+    return batchcatConnector.auth.updateRecord(recordId, record, catLocation, {
       username: userCredentials.username,
       password: userCredentials.password
     });
 
-    return recordId;
   }
 
   function deleteRecord(userCredentials, recordId) {
-    batchcatConnector.auth.deleteRecord(recordId, {
+    return batchcatConnector.auth.deleteRecord(recordId, {
       username: userCredentials.username,
       password: userCredentials.password
     });

--- a/lib/services/authority-service.js
+++ b/lib/services/authority-service.js
@@ -1,0 +1,51 @@
+// authorityService
+
+const utils = require('../utils');
+const constants = require('../constants');
+
+function createAuthorityService(options, batchcatConnector) {
+
+  function getRecord(recordId) {
+
+    const requestUrl = options.fetchApi.url + constants.FETCH_API_PATH_GET_RECORD + '?recordType=auth&recordId=' + recordId;
+    return utils.fetchResource(requestUrl, options.fetchApi.options)
+      .then((data) => utils.parseRecord(data));
+   
+  }
+
+  function updateRecord(userCredentials, library, catLocation, opacSuppress, recordId, record) {
+    
+    batchcatConnector.auth.addRecord(record, library, catLocation, opacSuppress, {
+      username: userCredentials.username,
+      password: userCredentials.password
+    });
+
+    return recordId;
+  }
+
+  function createRecord(userCredentials, library, catLocation, opacSuppress, record) {
+   
+    const recordId = batchcatConnector.auth.updateRecord(record, library, catLocation, opacSuppress, {
+      username: userCredentials.username,
+      password: userCredentials.password
+    });
+
+    return recordId;
+  }
+
+  function deleteRecord(userCredentials, recordId) {
+    batchcatConnector.auth.deleteRecord(recordId, {
+      username: userCredentials.username,
+      password: userCredentials.password
+    });
+  }
+
+  return {
+    get: getRecord,
+    update: updateRecord,
+    create: createRecord,
+    delete: deleteRecord
+  };
+}
+
+module.exports = createAuthorityService;

--- a/lib/services/authority-service.spec.js
+++ b/lib/services/authority-service.spec.js
@@ -1,0 +1,63 @@
+const sinon = require('sinon');
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+const expect = chai.expect;
+
+const fs = require('fs');
+const path = require('path');
+const Record = require('marc-record-js');
+
+const createAuthorityService = require('./authority-service');
+const utils = require('../utils');
+
+const fakeRecordData = fs.readFileSync(path.resolve(__dirname, '../../test-utils/fake-data/record-xml-slim.xml'), 'utf8');
+
+describe('Authority Service', () => {
+
+  let mockBatchcatConnector;
+  let authorityService;
+
+  const fakeConfig = {
+    fetchApi: {
+      url: 'fake-test-url'
+    }
+  };
+
+  beforeEach(() => {
+
+    mockBatchcatConnector = {
+      auth: {
+        addRecord: sinon.stub(),
+        updateRecord: sinon.stub(),
+        deleteRecord: sinon.stub()
+      }
+    };
+
+    sinon.stub(utils, 'fetchResource').callsFake(() => {
+      return new Promise((resolve) => resolve(fakeRecordData));
+    });
+
+    authorityService = createAuthorityService(fakeConfig, mockBatchcatConnector);
+
+  });
+  afterEach(() => {
+    utils.fetchResource.restore();
+  });
+
+  it('should be a factory function', () => {
+    expect(createAuthorityService).to.be.a('function');
+  });
+
+  describe('get authority record', () => {
+    it('should fetch the record using fetch api', () => {
+
+      return authorityService.get(123)
+        .then(data => {
+          expect(data).to.be.instanceOf(Record);
+          expect(utils.fetchResource).to.have.been.calledWith(sinon.match.string, sinon.match.any);
+        });
+
+    });
+  });
+});

--- a/lib/services/authority-service.spec.js
+++ b/lib/services/authority-service.spec.js
@@ -75,7 +75,7 @@ describe('Authority Service', () => {
       mockBatchcatConnector.auth.addRecord.resolves(123);
 
       return authorityService.create(fakeUserCredentials, fakeCatLocationId, fakeRecord)
-        .then(data => expect(data).to.equal(123));
+        .then(createdRecordId => expect(createdRecordId).to.equal(123));
     });
   });
 

--- a/lib/services/authority-service.spec.js
+++ b/lib/services/authority-service.spec.js
@@ -18,6 +18,11 @@ describe('Authority Service', () => {
   let mockBatchcatConnector;
   let authorityService;
 
+  const fakeUserCredentials = {
+    username: 'fake-username',
+    password: 'fake-password'
+  };
+
   const fakeConfig = {
     fetchApi: {
       url: 'fake-test-url'
@@ -58,6 +63,43 @@ describe('Authority Service', () => {
           expect(utils.fetchResource).to.have.been.calledWith(sinon.match.string, sinon.match.any);
         });
 
+    });
+  });
+
+  describe('create authority record', () => {
+    const fakeCatLocationId = 95;
+    const fakeRecord = 'fake-record';
+
+    it('should resolve to the recordId of just created record', () => {
+      
+      mockBatchcatConnector.auth.addRecord.resolves(123);
+
+      return authorityService.create(fakeUserCredentials, fakeCatLocationId, fakeRecord)
+        .then(data => expect(data).to.equal(123));
+    });
+  });
+
+
+  describe('update authority record', () => {
+    const fakeCatLocationId = 95;
+    const fakeRecord = 'fake-record';
+
+    it('should resolve without parameters if update is succesful', () => {
+      
+      mockBatchcatConnector.auth.updateRecord.resolves();
+
+      return authorityService.update(fakeUserCredentials, fakeCatLocationId, 123, fakeRecord);
+    });
+  });
+
+
+  describe('delete authority record', () => {
+
+    it('should resolve without parameters if update is succesful', () => {
+      
+      mockBatchcatConnector.auth.deleteRecord.resolves();
+
+      return authorityService.update(fakeUserCredentials, 123);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -28,29 +28,37 @@
   "license": "Apache-2.0",
   "version": "1.0.0",
   "main": "./lib/main",
-  "bin": ["./bin/voyager-http-api"],
+  "bin": [
+    "./bin/voyager-http-api"
+  ],
   "scripts": {
     "lint": "jshint .",
     "test": "istanbul cover _mocha",
     "cover": "npm run test && istanbul check-coverage",
     "check": "npm run lint && npm run cover",
     "travisci": "npm run check",
-    "publish-to-npm": "npm install && npm run check && npm publish"
+    "publish-to-npm": "npm install && npm run check && npm publish",
+    "test:unit": "mocha lib/**/*.spec.js",
+    "test:unit:watch": "mocha lib/**/*.spec.js -w"
   },
   "dependencies": {
-    "voyager-batchcat-js": "https://github.com/natlibfi/voyager-batchcat-js",
-    "marc-record-converters": "https://github.com/natlibfi/marc-record-converters",
-    "xmldom-xplat": "https://github.com/natlibfi/xmldom-xplat",
-    "express": "^4.14.0",    
     "body-parser": "^1.5.2",
+    "deep-assign": "^2.0.0",
+    "express": "^4.14.0",
+    "http-status-codes": "^1.1.6",
+    "marc-record-converters": "https://github.com/natlibfi/marc-record-converters",
     "moment": "^2.17.1",
-    "deep-assign": "^2.0.0"
+    "voyager-batchcat-js": "https://github.com/natlibfi/voyager-batchcat-js",
+    "xmldom-xplat": "https://github.com/natlibfi/xmldom-xplat"
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "codeclimate-test-reporter": "^0.4.0",
+    "istanbul": "^0.4.5",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
-    "istanbul": "^0.4.5",
-    "codeclimate-test-reporter": "^0.4.0"
+    "sinon": "^2.2.0",
+    "sinon-chai": "^2.10.0",
+    "supertest": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "deep-assign": "^2.0.0",
     "express": "^4.14.0",
     "http-status-codes": "^1.1.6",
+    "lodash.difference": "^4.5.0",
     "marc-record-converters": "https://github.com/natlibfi/marc-record-converters",
     "moment": "^2.17.1",
     "voyager-batchcat-js": "https://github.com/natlibfi/voyager-batchcat-js",

--- a/test-utils/fake-data/record-xml-slim.xml
+++ b/test-utils/fake-data/record-xml-slim.xml
@@ -1,0 +1,13 @@
+<records>
+   <collection>
+      <record>
+         <leader>00878cam a2200253 i 4500</leader>
+         <controlfield>12356</controlfield>
+         <controlfield>20110826153059.0</controlfield>
+         <controlfield>760910s1975    dcu      b   f000 0 eng  </controlfield>
+         <datafield tag="092" ind1=" " ind2=" ">
+           <subfield code="a">378.73 U58L</subfield>
+        </datafield>
+      </record>
+   </collection>
+</records>

--- a/test-utils/fake-data/record-xml-slim.xml
+++ b/test-utils/fake-data/record-xml-slim.xml
@@ -2,9 +2,9 @@
    <collection>
       <record>
          <leader>00878cam a2200253 i 4500</leader>
-         <controlfield>12356</controlfield>
-         <controlfield>20110826153059.0</controlfield>
-         <controlfield>760910s1975    dcu      b   f000 0 eng  </controlfield>
+         <controlfield tag="001">12356</controlfield>
+         <controlfield tag="005">20110826153059.0</controlfield>
+         <controlfield tag="008">760910s1975    dcu      b   f000 0 eng  </controlfield>
          <datafield tag="092" ind1=" " ind2=" ">
            <subfield code="a">378.73 U58L</subfield>
         </datafield>


### PR DESCRIPTION
This PR currently does not conform to the api designs. That should be fixed before merging.

The following stuff must be fixed in separate PR's:
* the Batchcat connector needs to be shared between bib/auth etc. routers to prevent multiple voyager sessions per user
* the main file should be refactored to enable better unit testing
* the bib routehandler does not currently have any tests
